### PR TITLE
remove xwaretech domains

### DIFF
--- a/constants/emailMasks.js
+++ b/constants/emailMasks.js
@@ -1787,9 +1787,6 @@ const masks = `@0-00.usa.cc
 @xoxy.net
 @xperiae5.com
 @xrho.com
-@xwaretech.com
-@xwaretech.info
-@xwaretech.net
 @xww.ro
 @xxi2.com
 @xxlocanto.us


### PR DESCRIPTION
They used to go to mailinator years ago but don't anymore. I control the domains and would appreciate not continuing to receive new account spam.